### PR TITLE
Fix absolute/relative URLs

### DIFF
--- a/src/saml_idp/config.py
+++ b/src/saml_idp/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     saml_idp_metadata_key_file: str = ""
     """The path of the SAML metadata key file."""
 
+    saml_idp_base_url: HttpUrl | Literal[""] = ""
+    """The Base URL used for the URLs in the SAML Metadata."""
+
     saml_idp_logout_url: HttpUrl | Literal[""] = ""
     """The logout URL to redirect to."""
 

--- a/src/saml_idp/urls.py
+++ b/src/saml_idp/urls.py
@@ -1,0 +1,20 @@
+"""Utilities for constructing relative URLs."""
+
+from typing import TYPE_CHECKING, Any
+
+from starlette.requests import Request
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette  # pragma: nocover
+    from starlette.routing import Router  # pragma: nocover
+
+
+def rel_url_for(req: Request, name: str, /, **path_params: Any) -> str:
+    """Provide a relative URL for a path."""
+    url_path_provider: Router | Starlette | None = req.scope.get(
+        "router"
+    ) or req.scope.get("app")
+    if url_path_provider is None:
+        msg = "`rel_url_for` method can only be used inside a Starlette application."
+        raise RuntimeError(msg)
+    return url_path_provider.url_path_for(name, **path_params)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -46,6 +46,17 @@ async def test_metadata_xml(ac: AsyncClient) -> None:
         schema.assertValid(etree.fromstring(xml))
 
 
+async def test_metadata_xml_base_url(ac: AsyncClient) -> None:
+    """You can use the base URL to change the signin/logout URLs."""
+    settings.saml_idp_base_url = "https://example.com"
+    response = await ac.get("/metadata.xml")
+    assert response.status_code == status.HTTP_200_OK
+    assert "text/xml" in response.headers["content-type"]
+    xml = response.content.decode()
+    assert "https://example.com/signin" in xml
+    assert "https://example.com/logout" in xml
+
+
 async def test_main_unauthenticated(ac: AsyncClient) -> None:
     """You can get the main page."""
     response = await ac.get("/login")

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,11 @@
+import pytest
+from starlette.requests import Request
+
+from saml_idp.urls import rel_url_for
+
+
+def test_rel_url_for_error() -> None:
+    """Throw an error when there's no router."""
+    req = Request({"type": "http"})
+    with pytest.raises(RuntimeError, match=r"can only be used"):
+        rel_url_for(req, "login")


### PR DESCRIPTION
1. All URLs in the HTML should be relative -- this makes configuration easier because we don't care if we're behind a proxy or not.
2. For the URLs that we need to be absolute -- the ones in the metadata -- allow for the base URL to be specified through settings, rather than inferred from the request.