### PR TITLE
Rename build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Build
 
 on:
   push:


### PR DESCRIPTION
So it's called "build", so the badge appears correct.